### PR TITLE
Update trigger platform version

### DIFF
--- a/inspector/an-inspector/ForgeModule/build.gradle
+++ b/inspector/an-inspector/ForgeModule/build.gradle
@@ -17,13 +17,6 @@ android {
         vanilla {
             dimension "default"
         }
-        crosswalk {
-            dimension "default"
-            minSdkVersion moduleMinSdkVersion() ?: 16
-            ndk {
-                abiFilters "armeabi-v7a", ""
-            }
-        }
     }
 
     sourceSets {
@@ -36,9 +29,6 @@ android {
             res.srcDirs = ["res"]
             assets.srcDirs = ["assets"]
             jniLibs.srcDirs = ["libs"]
-        }
-        crosswalk {
-            java.srcDirs = ["flavors/crosswalk/src"]
         }
         vanilla {
             java.srcDirs = ["flavors/vanilla/src"]
@@ -67,12 +57,16 @@ dependencies {
 
     implementation rootProject.ext.dependencies
 
-    crosswalkImplementation "org.xwalk:xwalk_core_library:" + rootProject.ext.crosswalkVersion
-
     vanillaImplementation (name:"ForgeCore-vanilla-debug", ext:"aar")
-    crosswalkImplementation (name:"ForgeCore-crosswalk-debug", ext:"aar")
 
     implementation moduleDependencies()
+
+    fileTree(dir: "libs", include: "**/*-vanilla-release.aar")
+    .each { File file ->
+        def name = file.name.lastIndexOf(".").with { it != -1 ? file.name[0..<it] : file.name }
+        dependencies.add("vanillaImplementation", [name: name , ext: "aar"])
+        println "Added module aar for vanilla: $name"
+    }
 }
 
 repositories{
@@ -98,25 +92,5 @@ task updateModule (dependsOn: ":ForgeModule:assembleRelease") {
         }
         println "\tUpdated module/android/ForgeModule-vanilla-release.aar"
 
-        copy {
-            from "build/outputs/aar/ForgeModule-crosswalk-release.aar"
-            into "../../../module/android"
-        }
-        println "\tUpdated module/android/ForgeModule-crosswalk-release.aar\n"
-    }
-}
-
-// Force Android support library version for Crosswalk builds
-configurations.all { conf ->
-    if (conf.name.contains("crosswalk")) {
-        println "Munging support library for: " + conf.name
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            def requested = details.requested
-            if (requested.group == "com.android.support") {
-                if (!requested.name.startsWith("multidex")) {
-                    details.useVersion rootProject.ext.supportLibraryVersion
-                }
-            }
-        }
     }
 }

--- a/inspector/an-inspector/build.gradle
+++ b/inspector/an-inspector/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath "com.android.tools.build:gradle:4.0.0"
         classpath "com.google.gms:google-services:4.3.2"
     }
     System.properties["com.android.build.gradle.overrideVersionCheck"] = "true"
@@ -17,9 +17,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url "https://download.01.org/crosswalk/releases/crosswalk/android/maven2"
-        }
         maven {
             url "https://maven.google.com"
         }
@@ -39,13 +36,16 @@ ext {
     dependencies = [
         "androidx.legacy:legacy-support-v4:1.0.0",
         "com.google.guava:guava:28.0-android",
+
+        // backports java.nio.file https://github.com/henrik-lindqvist/safs/tree/master/safs-android
+        "com.llamalab.safs:safs-android:0.2.0"
     ]
 
-    buildToolsVersion = "29.0.2"
+    buildToolsVersion = "30.0.0"
 
     minSdkVersion = moduleMinSdkVersion() ?: 14
-    compileSdkVersion = 29
-    targetSdkVersion = 29
+    compileSdkVersion = 30
+    targetSdkVersion = 30
 
     compileOptions = {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -64,12 +64,11 @@ ext {
         shrinkResources false
     }
 
-    crosswalkVersion = "23.53.589.4"
     supportLibraryVersion = "28.0.0"
 }
 
 wrapper {
-    gradleVersion = "5.6.2"
+    gradleVersion = "6.5.1"
 }
 
 task getHomeDir doLast {
@@ -141,20 +140,5 @@ def moduleResConfigs() {
         config["resConfigs"] ?: []
     } else {
         []
-    }
-}
-
-// Force Android support library version for Crosswalk builds
-configurations.all { conf ->
-    if (conf.name.contains("crosswalk")) {
-        println "Munging support library for: " + conf.name
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            def requested = details.requested
-            if (requested.group == "com.android.support") {
-                if (!requested.name.startsWith("multidex")) {
-                    details.useVersion rootProject.ext.supportLibraryVersion
-                }
-            }
-        }
     }
 }

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -1,5 +1,5 @@
 {
-    "changes": "* Update Parse Android SDK to 1.20.0",
+    "changes": "* rebuild for latest Trigger platform_version",
     "dependencies": {
         "bolts": {
             "minimum_version": "1.10.0",
@@ -7,8 +7,8 @@
         }
     },
     "description": "Parse.com configuration to enable push notifications.\n\nThe parse module uses the Parse.com SDK to allow for native push notifications.",
-    "min_platform_version": "v2.8.6",
+    "min_platform_version": "v2.9.1",
     "namespace": "parse",
-    "platform_version": "v2.8.6",
-    "version": "3.5.8"
+    "platform_version": "v2.9.1",
+    "version": "3.6.0"
 }


### PR DESCRIPTION
### What has been done
- bump the platform version to `2.9.1`
- bump gradle to `4.0.0`
- rebuild android module and ios module
- remove crosswalk target

### Why has this been done 
- to prepare the Trigger.io platform version update to `2.9.1`

### Tested on 
- iPhone 11, iOS 14.4
- Galaxy S8, Android 9

### How to test
- use `frontend#trigger-update-2.9` with a dev SLUG, and change version to `4.8`
- test notifications while app is in background and closed.

### Note
- changes to gradle files were done automatically, when running `gradle updateModule`